### PR TITLE
Bugfix: endDocument() called when root object ends

### DIFF
--- a/JsonStreamingParser.cpp
+++ b/JsonStreamingParser.cpp
@@ -279,7 +279,7 @@ void JsonStreamingParser::endObject() {
     }
     myListener->endObject();
     state = STATE_AFTER_VALUE;
-    if (stackPos == -1) {
+    if (stackPos == 0) {
       endDocument();
     }
   }


### PR DESCRIPTION
With a payload like this: 
{"key": "value"}
the event endDocument are never called, just endObject. This little change fixes that

The same issue like #4 but for object instead of array
