### PR TITLE
Added reset() to reuse parser

### DIFF
--- a/JsonStreamingParser.cpp
+++ b/JsonStreamingParser.cpp
@@ -26,6 +26,10 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 #include "JsonStreamingParser.h"
 
 JsonStreamingParser::JsonStreamingParser() {
+    reset();
+}
+
+void JsonStreamingParser::reset() {
     state = STATE_START_DOCUMENT;
     bufferPos = 0;
     unicodeEscapeBufferPos = 0;

--- a/JsonStreamingParser.h
+++ b/JsonStreamingParser.h
@@ -131,5 +131,5 @@ class JsonStreamingParser {
     JsonStreamingParser();
     void parse(char c);
     void setListener(JsonListener* listener);
-
+    void reset();
 };


### PR DESCRIPTION
If you want to allocate a parser once and reuse it to save memory,  the parser requires resetting to its initial state. I've added a new reset() method which enables you to do this.
