### PR TITLE
Allow changing buffer size

### DIFF
--- a/JsonStreamingParser.cpp
+++ b/JsonStreamingParser.cpp
@@ -202,7 +202,7 @@ void JsonStreamingParser::parse(char c) {
   }
 
 void JsonStreamingParser::increaseBufferPointer() {
-  bufferPos = min(bufferPos + 1, BUFFER_MAX_LENGTH - 1);
+  bufferPos = min(bufferPos + 1, JSON_PARSER_BUFFER_MAX_LENGTH - 1);
 }
 
 void JsonStreamingParser::endString() {

--- a/JsonStreamingParser.h
+++ b/JsonStreamingParser.h
@@ -49,7 +49,9 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 #define STACK_KEY                2
 #define STACK_STRING             3
 
-#define BUFFER_MAX_LENGTH  512
+#ifndef JSON_PARSER_BUFFER_MAX_LENGTH
+#define JSON_PARSER_BUFFER_MAX_LENGTH  512
+#endif
 
 class JsonStreamingParser {
   private:
@@ -62,7 +64,7 @@ class JsonStreamingParser {
 
     boolean doEmitWhitespace = false;
     // fixed length buffer array to prepare for c code
-    char buffer[BUFFER_MAX_LENGTH];
+    char buffer[JSON_PARSER_BUFFER_MAX_LENGTH];
     int bufferPos = 0;
 
     char unicodeEscapeBuffer[10];


### PR DESCRIPTION
I have a pretty memory-tight application and the parser buffer size of 512 was way overkill for my use-case (the largest individual keys/values are around 20 chars). I'm apparently not the first to have this issue. #19 

This PR allows you to override the buffer size, either through build flags or by defining the prop before the library is imported:

```cpp
#define JSON_PARSER_BUFFER_MAX_LENGTH 128
#include <JsonStreamingParser.h>
```

I renamed the definition to reduce the chance of conflicts with definitions in other code.