### PR TITLE
Fix for resetting stackPos

### DIFF
--- a/JsonStreamingParser.cpp
+++ b/JsonStreamingParser.cpp
@@ -35,6 +35,7 @@ void JsonStreamingParser::reset() {
     unicodeEscapeBufferPos = 0;
     unicodeBufferPos = 0;
     characterCounter = 0;
+    stackPos = 0;
 }
 
 void JsonStreamingParser::setListener(JsonListener* listener) {

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
     "name": "Daniel Eichhorn",
     "url": "http://blog.squix.ch"
   },
-  "version": "1.0.5",
+  "version": "1.0.6",
   "frameworks": "arduino",
   "platforms": "*",
   "examples": [


### PR DESCRIPTION
In the reset method the stack-Position was not reset. This leads to an overflow of the stack array when the parser is reused and (the previous document was not fully finished or the previous document was faulty).

The introduced fix resets the stackPos to 0 in the reset() method.