### PR TITLE
making the library cross platform to be abe to be used on native buids

### DIFF
--- a/JsonListener.h
+++ b/JsonListener.h
@@ -25,7 +25,7 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 
 #pragma once
 
-#include "multiplatform.h"
+#include "crossplatform.h"
 
 class JsonListener {
   private:

--- a/JsonListener.h
+++ b/JsonListener.h
@@ -25,7 +25,7 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 
 #pragma once
 
-#include <Arduino.h>
+#include "multiplatform.h"
 
 class JsonListener {
   private:

--- a/JsonStreamingParser.h
+++ b/JsonStreamingParser.h
@@ -25,7 +25,7 @@ See more at http://blog.squix.ch and https://github.com/squix78/json-streaming-p
 
 #pragma once
 
-#include <Arduino.h>
+#include "crossplatform.h"
 #include "JsonListener.h"
 
 #define STATE_START_DOCUMENT     0

--- a/crossplatform.h
+++ b/crossplatform.h
@@ -1,0 +1,35 @@
+#ifndef __MULTIPLATFORM_H__
+#define __MULTIPLATFORM_H__
+
+#ifdef ARDUINO 
+#include <Arduino.h>
+#else
+
+#include <string>
+// #include <string.h>
+
+template<typename T> inline T min(T a, T b){
+    return a > b ? b : a;
+} 
+template<typename T> inline T max(T a, T b){
+    return a > b ? a : b;
+} 
+
+typedef bool boolean;
+
+class String : public std::string {
+    public:
+        String(const char* c_str) : std::string(c_str) {}
+        String(std::string str) : std::string(str) {}
+        
+        boolean equals(String other){
+            return compare(other) == 0;
+        }
+
+        String operator +(String other){
+            return String(this->append(other));
+        }
+};
+
+#endif // ARDUINO
+#endif // __MULTIPLATFORM_H__


### PR DESCRIPTION
I'm usingg this library for a project where I need to parse a pretty comlpex JSON object. Testing my custom listener was a nightmare on the device itself, bt since it relies on Arduino's String implementation I couldn't build an x86 appication of it to debug step by step. 

Since the concept is very good (and I need it because the uC's few kB of RAM isn't enough to even store that particular JSON) I thought I'd add some macros and whatnot to make it easier in the future. this way it's only a few lines of config in Platformio to set up a native environment to debug.  